### PR TITLE
Add serialport and serial api for NodeJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "@protobuf-ts/runtime": "^2.2.1",
+    "serialport": "^9.2.8",
     "sub-events": "^1.8.9"
   },
   "devDependencies": {


### PR DESCRIPTION
# WIP

Uses [NodeJS WebStreams API](https://nodejs.org/api/webstreams.html) and [SerialPort](https://serialport.io/docs/api-serialport) to add NodeJS serial functionality.